### PR TITLE
Add const to NetworkConnect char* addr param

### DIFF
--- a/src/Platform/Arduino/MQTTArduino.cpp
+++ b/src/Platform/Arduino/MQTTArduino.cpp
@@ -110,7 +110,7 @@ void NetworkInit(Network* network, void* client, int chunkSize)
 }
 
 
-int NetworkConnect(Network* network, char* addr, int port)
+int NetworkConnect(Network* network, const char* addr, int port)
 {
 	Client* client = static_cast<Client*>(network->client);
 	return client->connect(addr, port);

--- a/src/Platform/Arduino/MQTTArduino.h
+++ b/src/Platform/Arduino/MQTTArduino.h
@@ -129,7 +129,7 @@ extern "C" {
 	* @param[in] port Destination port
 	* @return 0 if successfully connected, an error code otherwise
 	*/
-	int NetworkConnect(Network* network, char* addr, int port);
+	int NetworkConnect(Network* network, const char* addr, int port);
 
 	/**
 	* Close the connection.


### PR DESCRIPTION
While the parameter was indeed constant, `const` modifier was missing, which produced following warning during build:

```
Compiling .pioenvs\debug\lib7c2\ESP8266WiFi\WiFiClient.cpp.o
In file included from .piolibdeps\CayenneMQTT_ID1449\src/CayenneMQTTWiFiClient.h:21:0,
from src\main.cpp:24:
.piolibdeps\CayenneMQTT_ID1449\src/CayenneArduinoMQTTClient.h: In member function 'void CayenneArduinoMQTTClient::connect()':
.piolibdeps\CayenneMQTT_ID1449\src/CayenneArduinoMQTTClient.h:58:63: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
if (!NetworkConnect(&_network, CAYENNE_DOMAIN, CAYENNE_PORT)) {
```